### PR TITLE
Add github tests

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -3,7 +3,6 @@ package github
 import (
 	"encoding/json"
 	"io/ioutil"
-
 	"net/http"
 	"strconv"
 	"time"
@@ -94,7 +93,6 @@ func (ghclient *Client) Get(url string) (body []byte, err error) {
 	if err != nil {
 		return
 	}
-	req.SetBasicAuth(ghclient.Conf.Authtoken, "x-oauth-basic")
 
 	client := http.Client{}
 	res, err := client.Do(req)

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -1,0 +1,84 @@
+package github
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var SearchQueryNoDate = SearchQuery{
+	Repo:        "CapstoneLabs/slick",
+	Labels:      []string{"bug"},
+	ClosedSince: "",
+}
+
+var SearchQueryWithDate = SearchQuery{
+	Repo:        "CapstoneLabs/slick",
+	Labels:      []string{"bug"},
+	ClosedSince: "2018-10-03T18:16:21Z",
+}
+
+var user = GHUser{Login: "3sky"}
+
+var IssueEventClose = IssueEvent{
+	Actor: user,
+	Event: "closed",
+}
+var IssueItemNoNumber = IssueItem{
+	Assignee: user,
+	Events:   []IssueEvent{IssueEventClose},
+}
+
+var IssueEventOpen = IssueEvent{
+	Actor: user,
+	Event: "open",
+}
+
+var IssueItemWithNumber = IssueItem{
+	Number:   1,
+	Assignee: user,
+	Events:   []IssueEvent{IssueEventOpen},
+}
+
+var config = Conf{
+	Repos: []string{"3sky/slick"},
+}
+
+var TestClient = Client{Conf: config}
+
+func TestUrl(t *testing.T) {
+	test1 := SearchQueryNoDate.Url()
+	test2 := SearchQueryWithDate.Url()
+	assert.Equal(t, test1, "https://api.github.com/search/issues?q=+repo:CapstoneLabs/slick+label:bug")
+	assert.Equal(t, test2, "https://api.github.com/search/issues?q=+repo:CapstoneLabs/slick+label:bug+closed:>2018-10-03T18:16:21Z")
+}
+
+func TestLastClosedBy(t *testing.T) {
+	test1 := IssueItemNoNumber.LastClosedBy()
+	test2 := IssueItemWithNumber.LastClosedBy()
+	assert.Equal(t, test1, "3sky")
+	assert.Equal(t, test2, "")
+}
+
+func TestGet(t *testing.T) {
+	r, _ := TestClient.Get("https://api.github.com/repos/CapstoneLabs/slick/issues/1")
+	//366003717 ID of first issue
+	assert.Contains(t, string(r), "366003717")
+}
+
+func TestDoSearchQuery(t *testing.T) {
+	QueryResult, _ := TestClient.DoSearchQuery(SearchQueryWithDate)
+	//Get first close issues since "2018-10-03T18:16:21Z" - #13
+	FirstClosedIssue := fmt.Sprintf("%+v", QueryResult[len(QueryResult)-1])
+	assert.Contains(t, FirstClosedIssue, "Fix typos")
+}
+
+func TestDoEventQuery(t *testing.T) {
+	ch := make(chan IssueItem)
+	go TestClient.DoEventQuery([]IssueItem{IssueItemWithNumber}, "CapstoneLabs/slick", ch)
+	x := <-ch
+	EventID := x.Events[0].ID
+	//ID of First Event on #1 issue in CapstoneLabs/slick
+	assert.Equal(t, EventID, 1879968249)
+}


### PR DESCRIPTION
Finally I created nice test cases with `testify` and pretty coverage.
```commandline
Running tool: /usr/bin/go test -timeout 30s slick/github -coverprofile=/tmp/vscode-goP5ex9T/go-code-cover

ok  	slick/github	1.190s	coverage: 88.9% of statements
Success: Tests passed.
```
Also I removed `req.SetBasicAuth(ghclient.Conf.Authtoken, "x-oauth-basic")` now it could be:
```golang
token := "token" + ghclient.Conf.Authtoken
req.Hedaer.Set("Authorization", token) 
```
But `slick` is open repo, so We don't need API key :) 