### PR TITLE
don't use log.Fatal in defer to close db

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -99,7 +99,7 @@ func (bot *Bot) Run() {
 		log.Fatalf("Could not initialize BoltDB key/value store: %s", err)
 	}
 	defer func() {
-		log.Fatal("Database is closing")
+		log.Warnf("Database is closing")
 		db.Close()
 	}()
 	bot.DB = db


### PR DESCRIPTION
`log.Fatal` does `Exit(1)` so it kills the whole process right in that moment.

this actually results in `db.Close()` never being called, but the main reason for not using `log.Fatal` in this defer is that it prevents any other runtime errors from bubbling up so you never get to know what really crashed the process.

tbh personally I think using `log.Fatal` isn't a good choice at all, should use `panic(errors.Error())` since will give you a stack trace and all.